### PR TITLE
redirect.js: skip links that have already been rewritten

### DIFF
--- a/src/static/redirect.js
+++ b/src/static/redirect.js
@@ -42,6 +42,11 @@ if (globalThis.fetch) {
                 return;
               }
 
+              if (href.includes(root)) {
+                // don't try to redirect links that have already been rewritten
+                return;
+              }
+
               href = encodeURIComponent(href);
 
               // default to unrot.link with the url


### PR DESCRIPTION
Since the script is writing the new redirect URL back to target.href, if you click the link again, it will recursively redirect.

To reproduce:
 - Go to https://unrot.link/try/
 - Command click on the haveamint link to open it in a new tab
   - The href for the link is now `https://unrot.link/?url=https%3A%2F%2Fhaveamint.com`
 - Command click on the same link again
   - The href for the link is now `https://unrot.link/?url=https%3A%2F%2Funrot.link%2F%3Furl%3Dhttps%253A%252F%252Fhaveamint.com`
 - Repeat as necessary for desired level of recursion